### PR TITLE
fix "launcher" field in manifest as required by SDK 0.5.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,8 +5,8 @@
   "title": "Highlightr Iframe",
   "description": "Iframe launcher-compatible syntax highlighter",
   "author": "Ryan Jones",
+  "launcher": "iframe",
   "defaultConfig": {
-    "__launcher": "iframe"
   },
   "defaultUserState": {}
 }


### PR DESCRIPTION
The layout of the "launcher" field has changed.
